### PR TITLE
Add raster support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,16 @@ version = "0.1.0"
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
-LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+RasterDataSources = "3cb90ccd-e1b6-4867-9617-4276c8b2ca36"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+XML = "72c71f33-b9b6-44de-8c94-c961784809e2"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 GeoJSON = "0.6"
+RasterDataSources = "0.5"
+XML = "0.1.3"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,12 @@ authors = ["Haakon Ludvig Langeland Ervik (@haakon-e), Anshul Singhvi <anshulsin
 version = "0.1.0"
 
 [deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
+LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 GeoJSON = "0.6"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # NaturalEarth.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://asinghvi17.github.io/NaturalEarth.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://asinghvi17.github.io/NaturalEarth.jl/dev/)
-[![Build Status](https://github.com/asinghvi17/NaturalEarth.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/asinghvi17/NaturalEarth.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeo.github.io/NaturalEarth.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeo.github.io/NaturalEarth.jl/dev/)
+[![Build Status](https://github.com/JuliaGeo/NaturalEarth.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/NaturalEarth.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
 
 This package provides a Julia interface to the [Natural Earth](http://www.naturalearthdata.com/) dataset. The Natural Earth dataset is a public domain map dataset available at 1:10m, 1:50m, and 1:110 million scales. It is ideal for small-scale thematic mapping and for creating static maps and illustrations.
 
-Currently, this package provides a single function, `naturalearth`, which fetches any `.geojson` file from [this](https://github.com/nvkelso/natural-earth-vector/tree/master/geojson) repository. The function returns a `GeoJSON.FeatureCollection` object.
+Currently, this package provides a single function, `naturalearth(dataset_name::String)`, which fetches any `.geojson` file from [this](https://github.com/nvkelso/natural-earth-vector/tree/master/geojson) repository. The function returns a `GeoJSON.FeatureCollection` object, from the [`GeoJSON.jl`](httos://github.com/JuliaGeo/GeoJSON.jl) package.
 
 The data is downloaded on demand and cached using Julia's `Artifacts` system. This means that the first time you fetch a dataset, it will take a while to download, and you will need an internet connection. Subsequent calls will be much faster, even in a new session.
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,11 +6,11 @@ DocMeta.setdocmeta!(NaturalEarth, :DocTestSetup, :(using NaturalEarth); recursiv
 makedocs(;
     modules=[NaturalEarth],
     authors="Anshul Singhvi <anshulsinghvi@gmail.com> and contributors",
-    repo="https://github.com/asinghvi17/NaturalEarth.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/JuliaGeo/NaturalEarth.jl/blob/{commit}{path}#{line}",
     sitename="NaturalEarth.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://asinghvi17.github.io/NaturalEarth.jl",
+        canonical="https://JuliaGeo.github.io/NaturalEarth.jl",
         edit_link="main",
         assets=String[],
     ),
@@ -20,6 +20,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/asinghvi17/NaturalEarth.jl",
+    repo="github.com/JuliaGeo/NaturalEarth.jl",
     devbranch="main",
 )

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -4,6 +4,7 @@ import GeoJSON
 using Pkg
 using Pkg.Artifacts
 
+"A list of the names of available artifacts"
 const available_artifacts = collect(keys(
     Artifacts.select_downloadable_artifacts(Artifacts.find_artifacts_toml(@__FILE__); include_lazy=true)
 ))
@@ -11,19 +12,22 @@ const available_artifacts = collect(keys(
 export naturalearth, bathymetry
 
 """
-    naturalearth(name::String)
+    naturalearth(dataset_name::String)
 
 Load a NaturalEarth dataset as a `GeoJSON.FeatureCollection` object.
 
 Valid names are found in `Artifacts.toml`. 
 We aim to support all datasets listed in https://github.com/nvkelso/natural-earth-vector/tree/master/geojson
 """
-function naturalearth(name::String)
-    pth = @artifact_str("$name/$name.geojson")
-    @assert isfile(pth) "`$name` is not a valid NaturalEarth.jl artifact"
-    GeoJSON.read(read(pth, String))
+function naturalearth(dataset_name::String)
+    file_path = @artifact_str("$dataset_name/$dataset_name.geojson")
+    @assert isfile(file_path) """
+    `$dataset_name` is not a valid NaturalEarth.jl artifact!
+    Please search https://www.naturalearthdata.com for available
+    datasets.
+    """
+    GeoJSON.read(read(file_path, String))
 end
-
 
 """
     bathymetry(contour::Int = 2000)
@@ -48,7 +52,5 @@ function bathymetry(contour::Int=2000)
     bathyfile = bathyfiles[fileind]
     return naturalearth(bathyfile)
 end
-
-
 
 end  # end module

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -6,7 +6,8 @@ using Pkg.Artifacts
 using p7zip_jll
 using Scratch
 using Downloads
-using LightXML
+using XML
+using RasterDataSources
 
 download_cache = ""
 
@@ -15,7 +16,7 @@ const available_artifacts = collect(keys(
     Artifacts.select_downloadable_artifacts(Artifacts.find_artifacts_toml(@__FILE__); include_lazy=true)
 ))
 
-export naturalearth, bathymetry
+export naturalearth, bathymetry, NaturalEarthRaster, ne_raster
 
 """
     naturalearth(dataset_name::String)
@@ -29,7 +30,7 @@ function naturalearth(dataset_name::String)
     if dataset_name ∈ available_artifacts
         file_path = @artifact_str("$dataset_name/$dataset_name.geojson")
         return GeoJSON.read(read(file_path, String))
-    elseif dataset_name ∈ available_rasters
+    # elseif dataset_name ∈ available_rasters
     end
 
     @assert isfile(file_path) """
@@ -66,20 +67,98 @@ end
 
 # Get rasters from AWS
 
-function get_available_rasters(refresh = false)
-    scratchspace = Scratch.@get_scratch!("rasters")
-    xml_file = joinpath(scratchspace, "index.xml")
-    # refresh the XML file
-    if !isfile(xml_file) || refresh
-        download("https://naturalearth.s3.amazonaws.com/", xml_file)
-    end
-    # read the document
-    xml_doc = LightXML.parse_file(xml_file);
-    # get the root node
-    xml_root = LightXML.root(xml_doc);
-    @assert name(xml_root) == "ListBucketResult" "The format of the NaturalEarth data dictionary at Amazon AWS has changed, or the file is invalid.  Please file an issue at https://github.com/JuliaGeo/NaturalEarth.jl/issues."
-    return deepcopy(attributes_dict(xml_root))
+# function get_available_rasters(refresh = false)
+#     scratchspace = Scratch.@get_scratch!("rasters")
+#     xml_file = joinpath(scratchspace, "index.xml")
+#     # refresh the XML file
+#     if !isfile(xml_file) || refresh
+#         download("https://naturalearth.s3.amazonaws.com/", xml_file)
+#     end
+#     # read the document
+#     xml_doc = LightXML.parse_file(xml_file);
+#     # get the root node
+#     xml_root = LightXML.root(xml_doc);
+#     @assert name(xml_root) == "ListBucketResult" "The format of the NaturalEarth data dictionary at Amazon AWS has changed, or the file is invalid.  Please file an issue at https://github.com/JuliaGeo/NaturalEarth.jl/issues."
+#     return deepcopy(attributes_dict(xml_root))
+# end
+
+# function available_rasters_dict(keys)
+#     retval = Dict{String, Vector{VersionNumber}}()
+#     for key_element in keys
+#         key_str = key_element[1]
+#         endswith(key_str, "/") && continue # discard directory specs
+#         if haskey(key_str, "raster")
+#             name = splitext(basename(key_str))[1]
+#             dirs = splitpath(name)
+
+#             version = if length(dirs) == 1 || !(occursin(".", dirs[1])) # no version number
+#                 VersionNumber(typemax(UInt32))
+#             else
+#                 VersionNumber(dirs[1])
+#             end
+
+#             # for i in 1
+#     end
+# end
+
+# Implement the RasterDataSources.jl interface.
+# With this, you can call e.g. 
+# Rasters.Raster(NaturalEarthRaster{:latest, 10, :HYP_HR}, nothing)
+
+struct NaturalEarthRaster{Version, Scale, Name} <: RasterDataSources.RasterDataSource end
+
+ne_raster(; version = nothing, scale::Int = 10, name::Int) = NaturalEarthRaster{version == nothing ? Symbol(VersionNumber(typemax(UInt32))), scale, Symbol(name)}
+
+const _NATURALEARTH_URI = RasterDataSources.URIs.URI(scheme="https", host="naturalearth.s3.amazonaws.com", path="/")
+
+function _zippath(::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return if Version == :latest || VersionNumber(string(Version)).major == typemax(UInt32)
+        "" # max version, so latest
+    else
+        string(Version) * "/"
+    end * if Scale == 110 || Scale == 50 || Scale == 10
+        string(Scale) * "m_raster"
+    else
+        error("Invalid scale: $Scale")
+    end * "/" * string(Name) * ".zip"
 end
+
+function RasterDataSources.zippath(::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return joinpath(RasterDataSources.rasterpath(), "NaturalEarth", "zips", split(_zippath(NaturalEarthRaster{Version, Scale, Name}), "/")...)
+end
+
+function RasterDataSources.zipurl(::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return RasterDataSources.URIs.URI(_NATURALEARTH_URI; path = "/" * _zippath(NaturalEarthRaster{Version, Scale, Name}))
+end
+
+function RasterDataSources.zipname(::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return splitpath(_zippath(NaturalEarthRaster{Version, Scale, Name}))[end]
+end
+
+function RasterDataSources.rasterpath(T::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return joinpath(RasterDataSources.rasterpath(), "NaturalEarth", split((_zippath(NaturalEarthRaster{Version, Scale, Name})), "/")[1:end-1]..., RasterDataSources.rastername(T))
+end
+
+function RasterDataSources.rastername(::Type{NaturalEarthRaster{Version, Scale, Name}}) where {Version, Scale, Name}
+    return string(Name) * ".tif"
+end
+
+function RasterDataSources.getraster(T::Type{NaturalEarthRaster{Version, Scale, Name}}, layer = nothing) where {Version, Scale, Name}
+    raster_path = RasterDataSources.rasterpath(T)
+    if !isfile(raster_path)
+        zip_path = RasterDataSources.zippath(T)
+        RasterDataSources._maybe_download(RasterDataSources.zipurl(T), zip_path)
+        zf = RasterDataSources.ZipFile.Reader(zip_path)
+        mkpath(dirname(raster_path))
+        raster_name = RasterDataSources.rastername(T)
+        @show zf
+        write(raster_path, read(RasterDataSources._zipfile_to_read(joinpath(splitext(raster_name)[1], raster_name), zf)))
+        close(zf)
+    end
+    return raster_path
+end
+
+
 
 function _unpack_zip(zipfile, outputdir)
     out = Pipe()
@@ -108,4 +187,91 @@ function __init__()
     global download_cache = Scratch.get_scratch!(@__MODULE__, "rasters")
 end
 
-end  # end module
+# Raster API - hook into RasterDataSources
+
+function check_scale(scale::Int)
+    return scale in (110, 50, 10)
+end
+
+function ne_file_name(scale::Int, type::String, category::String)
+    if type in (
+        "countries",
+        "map_units",
+        "map_subunits",
+        "sovereignty",
+        "tiny_countries",
+        "boundary_lines_land",
+        "pacific_groupings",
+        "breakaway_disputed_areas",
+        "boundary_lines_disputed_areas",
+        "boundary_lines_maritime_indicator")
+        type = "admin_0_" * type
+    elseif type == "states"
+        type = "admin_1_" * type
+    end
+
+    
+    if category == "raster"
+        return type
+    else
+        return "ne_$(scale)m_$(type)"
+    end
+end
+
+function(scale = 110,
+#                          type = "countries",
+#                          category = c("cultural", "physical", "raster"),
+#                          full_url = FALSE) {
+#   # check on permitted scales, convert names to numeric
+#   scale <- check_scale(scale)
+
+#   # check permitted category
+#   category <- match_arg(category)
+
+
+#   # add admin_0 to known types
+#   if (type %in% c(
+#     "countries",
+#     "map_units",
+#     "map_subunits",
+#     "sovereignty",
+#     "tiny_countries",
+#     "boundary_lines_land",
+#     "pacific_groupings",
+#     "breakaway_disputed_areas",
+#     "boundary_lines_disputed_areas",
+#     "boundary_lines_maritime_indicator"
+#   )) {
+#     type <- paste0("admin_0_", type)
+#   }
+
+
+#   # add admin_1 to known types
+#   # this actually just expands 'states' to the name including lakes
+#   if (type == "states") {
+#     type <- "admin_1_states_provinces_lakes"
+#   }
+
+
+#   if (category == "raster") {
+#     # raster seems not to have so straightforward naming, so require that name
+#     # is passed in type
+#     file_name <- paste0(type)
+#   } else {
+#     file_name <- paste0("ne_", scale, "m_", type)
+#   }
+
+
+#   # https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_0_countries.zip
+#   if (full_url) {
+#     file_name <- paste0(
+#       "https://naturalearth.s3.amazonaws.com/",
+#       scale, "m_", category, "/",
+#       file_name, ".zip"
+#     )
+#   }
+
+#   return(file_name)
+# }
+
+# end  # end module

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -69,8 +69,7 @@ function _unpack_zip(zipfile, outputdir)
     try
         run(pipeline(`$(p7zip_jll.p7zip()) e $zipfile -o$outputdir -y `, stdout = out, stderr = err))
     catch e
-
-        printstyled("Error in unzipping!"; bold = true, color = :red)
+        printstyled("Error while unzipping!"; bold = true, color = :red)
         println()
         printstyled("Stdout:"; bold = false, color = :blue)
         println(read(out, String))

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -155,7 +155,7 @@ function RasterDataSources.getraster(T::Type{NaturalEarthRaster{Version, Scale, 
         mkpath(dirname(raster_path))
         raster_name = RasterDataSources.rastername(T)
         @show zf
-        write(raster_path, read(RasterDataSources._zipfile_to_read(raster_name, zf)))
+        write(raster_path, read(_zipfile_to_read(raster_name, zf)))
         close(zf)
     end
     return raster_path

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -161,31 +161,6 @@ function RasterDataSources.getraster(T::Type{NaturalEarthRaster{Version, Scale, 
     return raster_path
 end
 
-
-
-function _unpack_zip(zipfile, outputdir)
-    out = Pipe()
-    err = Pipe()
-    try
-        run(pipeline(`$(p7zip_jll.p7zip()) e $zipfile -o$outputdir -y `, stdout = out, stderr = err))
-    catch e
-        printstyled("Error while unzipping!"; bold = true, color = :red)
-        println()
-        printstyled("Stdout:"; bold = false, color = :blue)
-        println(read(out, String))
-        printstyled("Stderr:"; bold = false, color = :red)
-        println(read(err, String))
-        rethrow(e)
-    end
-end
-
-function _download_unpack(url::String, path = splitext(basename(url))[1])
-    scratchspace = Scratch.@get_scratch!("rasters")
-    unpack_path = mkpath(joinpath(scratchspace, path))
-    zipfile = Downloads.download(url)
-    _unpack_zip(zipfile, unpack_path)
-end
-
 function __init__()
     global download_cache = Scratch.get_scratch!(@__MODULE__, "rasters")
 end

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -63,6 +63,24 @@ function bathymetry(contour::Int=2000)
     return naturalearth(bathyfile)
 end
 
+
+# Get rasters from AWS
+
+function get_available_rasters(refresh = false)
+    scratchspace = Scratch.@get_scratch!("rasters")
+    xml_file = joinpath(scratchspace, "index.xml")
+    # refresh the XML file
+    if !isfile(xml_file) || refresh
+        download("https://naturalearth.s3.amazonaws.com/", xml_file)
+    end
+    # read the document
+    xml_doc = LightXML.parse_file(xml_file);
+    # get the root node
+    xml_root = LightXML.root(xml_doc);
+    @assert name(xml_root) == "ListBucketResult" "The format of the NaturalEarth data dictionary at Amazon AWS has changed, or the file is invalid.  Please file an issue at https://github.com/JuliaGeo/NaturalEarth.jl/issues."
+    return deepcopy(attributes_dict(xml_root))
+end
+
 function _unpack_zip(zipfile, outputdir)
     out = Pipe()
     err = Pipe()

--- a/src/NaturalEarth.jl
+++ b/src/NaturalEarth.jl
@@ -6,6 +6,7 @@ using Pkg.Artifacts
 using p7zip_jll
 using Scratch
 using Downloads
+using LightXML
 
 download_cache = ""
 
@@ -79,15 +80,15 @@ function _unpack_zip(zipfile, outputdir)
     end
 end
 
-function _download_unpack(url::String)
-    scratchspace = Scratch.@get_scratch!("raster")
-    path = mkdir(joinpath(scratchspace, splitext(basename(url))[1]))
+function _download_unpack(url::String, path = splitext(basename(url))[1])
+    scratchspace = Scratch.@get_scratch!("rasters")
+    unpack_path = mkpath(joinpath(scratchspace, path))
     zipfile = Downloads.download(url)
-    _unpack_zip(zipfile, path)
+    _unpack_zip(zipfile, unpack_path)
 end
 
 function __init__()
-    global download_cache = Scratch.get_scratch!(@__MODULE__, "raster")
+    global download_cache = Scratch.get_scratch!(@__MODULE__, "rasters")
 end
 
 end  # end module


### PR DESCRIPTION
This is a basic implementation of RasterDataSources.jl for NaturalEarth.  With this, the code:

```julia
using NaturalEarth, Rasters, CairoMakie
# All NaturalEarth rasters are tiffs, 
# so we have to convert them manually to matrices of colors
# This might be better solved in Rasters.jl!
tiff = Raster(NaturalEarthRaster{:latest, 10, :HYP_HR}, 1)
tiff_image = Makie.RGBf.(eachslice(tiff, dims=3)...) ./ 255
image(tiff_image)
```
just works!
![download-3](https://user-images.githubusercontent.com/32143268/227838569-d172926b-bac6-4266-9185-0a593c4164f7.png)

